### PR TITLE
Bug fix of US Keyboard Quotes and pedantic quote reordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,20 +193,20 @@
 							<span class="key">option</span><span class="key">[</span><span class="sample">“</span><br>
 							<span class="key">option</span><span class="key">shift</span><span class="key">[</span><span class="sample">”</span><br>
 							<span class="key">option</span><span class="key">]</span><span class="sample">‘</span><br>
-							<span class="key">option</span><span class="key">shift</span><span class="key">]</span><span class="sample">’</span>
+							<span class="key">option</span><span class="key">shift</span><span class="key">]</span><span class="sample">’</span><br>
+							<span class="key">option</span><span class="key">\</span><span class="sample">«</span><br>
 							<span class="key">option</span><span class="key">shift</span><span class="key">\</span><span class="sample">»</span>
-							<span class="key">option</span><span class="key">\</span><span class="sample">«</span>
 						</p>
 					</div>
 					<div class="grid-6">
 						<h6>German Keyboard</h6>
 						<p>
-							<span class="key">alt</span><span class="key">shift</span><span class="key">2</span><span class="sample">”</span><br>
 							<span class="key">alt</span><span class="key">2</span><span class="sample">“</span><br>
+							<span class="key">alt</span><span class="key">shift</span><span class="key">2</span><span class="sample">”</span><br>
 							<span class="key">alt</span><span class="key">#</span><span class="sample">‘</span><br>
 							<span class="key">alt</span><span class="key">shift</span><span class="key">#</span><span class="sample">’</span><br>
-							<span class="key">alt</span><span class="key">shift</span><span class="key">Q</span><span class="sample">»</span>
-							<span class="key">alt</span><span class="key">Q</span><span class="sample">«</span>
+							<span class="key">alt</span><span class="key">Q</span><span class="sample">«</span><br>
+							<span class="key">alt</span><span class="key">shift</span><span class="key">Q</span><span class="sample">»</span><br>
 							<span class="key">alt</span><span class="key">shift</span><span class="key">W</span><span class="sample">„</span><br>
 							<span class="key">alt</span><span class="key">2</span><span class="sample">“</span><br>
 							<span class="key">alt</span><span class="key">S</span><span class="sample">‚</span><br>


### PR DESCRIPTION
I found a bug in the “ and ” shortcuts: (Option [) was marked as giving ” and vice-versa and fixed. Also, the second commit is a reordering of the quote shortcuts into a pedantic “Open, then Close quotes” order that matches up across the languages. 
